### PR TITLE
fix: Change the test query names lat/lng to match backend expectation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Flutter Tests
 
 on:
   push:
-    branches: [main, develop, feature/*]
+    branches: [main, develop, feature/*, fix/*]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, feature/*, fix/*]
 
 jobs:
   test:
@@ -94,4 +94,3 @@ jobs:
 
       - name: Build iOS (no codesign)
         run: flutter build ios --debug --no-codesign
-

--- a/lib/core/utils/image_url_helper.dart
+++ b/lib/core/utils/image_url_helper.dart
@@ -1,17 +1,19 @@
 import '../config/env.dart';
 
 /// Helper class for transforming image URLs to use backend S3 proxy
-/// 
-/// Transforms LocalStack S3 URLs (localhost:4566) to use the backend's
-/// S3 proxy endpoint, which is accessible via ngrok in development.
-/// 
+///
+/// Transforms LocalStack S3 URLs to use the backend's S3 proxy endpoint,
+/// which is accessible via ngrok in development.
+///
 /// Example transformations:
 /// - Input:  http://localhost:4566/smatch-photos/users/123/profile.jpg
 /// - Output: https://your-ngrok-url.ngrok.io/api/s3-proxy/smatch-photos/users/123/profile.jpg
 class ImageUrlHelper {
-  static const String _localhostS3Pattern = 'http://localhost:4566/';
+  static final RegExp _localS3Pattern = RegExp(
+    r'^http://(localhost|127\.0\.0\.1|localstack|s3\.localhost\.localstack\.cloud):4566/',
+  );
   static const String _s3ProxyPath = '/api/s3-proxy/';
-  
+
   /// Headers required for loading images through ngrok proxy.
   /// ngrok free tier shows an interstitial page unless this header is present.
   static Map<String, String> get imageHeaders {
@@ -21,28 +23,28 @@ class ImageUrlHelper {
     }
     return {};
   }
-  
+
   /// Transform S3 image URL to use backend proxy
-  /// 
-  /// If the URL contains localhost:4566, it replaces it with the API base URL
-  /// and adds the /api/s3-proxy/ path.
-  /// 
+  ///
+  /// If the URL contains a LocalStack S3 host, it replaces it with the API
+  /// base URL and adds the /api/s3-proxy/ path.
+  ///
   /// Otherwise, returns the URL unchanged.
   static String transformImageUrl(String url) {
-    if (url.startsWith(_localhostS3Pattern)) {
-      // Extract the bucket and key from localhost URL
-      // Format: http://localhost:4566/bucket/key/path
-      final path = url.substring(_localhostS3Pattern.length);
-      
+    final match = _localS3Pattern.firstMatch(url);
+    if (match != null) {
+      // Extract the bucket and key from the LocalStack URL.
+      final path = url.substring(match.end);
+
       // Construct proxied URL through backend
       // Format: https://api-base-url/api/s3-proxy/bucket/key/path
       return '${Env.apiBaseUrl}$_s3ProxyPath$path';
     }
-    
+
     // If already using proxy path or external URL, return as-is
     return url;
   }
-  
+
   /// Transform a list of image URLs
   static List<String> transformImageUrls(List<String> urls) {
     return urls.map((url) => transformImageUrl(url)).toList();

--- a/lib/views/matches/widgets/match_card.dart
+++ b/lib/views/matches/widgets/match_card.dart
@@ -25,10 +25,7 @@ class MatchCard extends StatelessWidget {
       elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
-        side: BorderSide(
-          color: Colors.grey.withValues(alpha: 0.2),
-          width: 1,
-        ),
+        side: BorderSide(color: Colors.grey.withValues(alpha: 0.2), width: 1),
       ),
       color: Colors.white,
       child: InkWell(
@@ -37,258 +34,279 @@ class MatchCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Match image (if available)
-            if (match.images.isNotEmpty)
-              ClipRRect(
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-                child: CachedNetworkImage(
-                  imageUrl: ImageUrlHelper.transformImageUrl(match.images[0]),
-                  httpHeaders: ImageUrlHelper.imageHeaders,
-                  height: 180,
-                  width: double.infinity,
-                  fit: BoxFit.cover,
-                  placeholder: (context, url) => Container(
-                    height: 180,
-                    color: Colors.grey.shade200,
-                    child: const Center(
-                      child: CircularProgressIndicator(),
-                    ),
-                  ),
-                  errorWidget: (context, url, error) => Container(
-                    height: 180,
-                    color: Colors.grey.shade200,
-                    child: const Center(
-                      child: Icon(
-                        Icons.image_not_supported_outlined,
-                        size: 48,
-                        color: Colors.grey,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
+            _buildMediaArea(),
 
             Padding(
               padding: const EdgeInsets.all(16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-              // Header row: Title + Status badge
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          match.title,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                            color: AppTheme.textPrimary,
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        if (isHosted) ...[
-                          const SizedBox(height: 4),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 2,
-                            ),
-                            decoration: BoxDecoration(
-                              color: AppTheme.primaryColor.withValues(alpha: 0.1),
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: const Text(
-                              'Host',
-                              style: TextStyle(
-                                fontSize: 10,
-                                fontWeight: FontWeight.w600,
-                                color: AppTheme.primaryColor,
+                  // Header row: Title + Status badge
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              match.title,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                                color: AppTheme.textPrimary,
                               ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
                             ),
-                          ),
-                        ],
-                        // Private match indicator
-                        if (match.isPrivate) ...[
-                          const SizedBox(height: 4),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 2,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.purple.withValues(alpha: 0.1),
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: const Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  Icons.lock_outline,
-                                  size: 10,
-                                  color: Colors.purple,
+                            if (isHosted) ...[
+                              const SizedBox(height: 4),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 2,
                                 ),
-                                SizedBox(width: 4),
-                                Text(
-                                  'Private',
+                                decoration: BoxDecoration(
+                                  color: AppTheme.primaryColor.withValues(
+                                    alpha: 0.1,
+                                  ),
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: const Text(
+                                  'Host',
                                   style: TextStyle(
                                     fontSize: 10,
                                     fontWeight: FontWeight.w600,
-                                    color: Colors.purple,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  _StatusBadge(status: match.status),
-                ],
-              ),
-
-              const SizedBox(height: 12),
-
-              // Court info
-              if (match.court != null) ...[
-                _InfoRow(
-                  icon: Icons.location_on_outlined,
-                  text: match.court!.name,
-                  secondaryText: match.court!.addressDistrict,
-                ),
-                const SizedBox(height: 8),
-              ],
-
-              // Date and time
-              _InfoRow(
-                icon: Icons.calendar_today_outlined,
-                text: _formatDate(match.date),
-                secondaryText: '${match.startTime} - ${match.endTime}',
-              ),
-
-              const SizedBox(height: 12),
-
-              // Tags row: Skill level, format, slots
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  _Tag(
-                    icon: Icons.bar_chart,
-                    label: match.skillLevel.displayName,
-                    color: AppTheme.primaryColor,
-                  ),
-                  _Tag(
-                    icon: Icons.people_outline,
-                    label: match.playerFormat.displayName,
-                    color: Colors.blue,
-                  ),
-                  _Tag(
-                    icon: Icons.person_add_outlined,
-                    label: '${match.totalPlayersCount}/${match.slotsNeeded}',
-                    color: match.isFull ? Colors.orange : Colors.green,
-                  ),
-                ],
-              ),
-
-              const SizedBox(height: 12),
-
-              // Bottom row: Price + Host info
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  // Price
-                  Text(
-                    _formatPrice(match.price),
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                      color: AppTheme.primaryColor,
-                    ),
-                  ),
-
-                  // Host info
-                  if (match.host != null && !isHosted)
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        CircleAvatar(
-                          radius: 12,
-                          backgroundColor: AppTheme.primaryColor.withValues(alpha: 0.1),
-                          backgroundImage: match.host!.avatarUrl != null
-                              ? NetworkImage(
-                                  ImageUrlHelper.transformImageUrl(match.host!.avatarUrl!),
-                                  headers: ImageUrlHelper.imageHeaders,
-                                )
-                              : null,
-                          child: match.host!.avatarUrl == null
-                              ? Text(
-                                  match.host!.displayName?.isNotEmpty == true
-                                      ? match.host!.displayName![0].toUpperCase()
-                                      : 'U',
-                                  style: const TextStyle(
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.bold,
                                     color: AppTheme.primaryColor,
                                   ),
-                                )
-                              : null,
+                                ),
+                              ),
+                            ],
+                            // Private match indicator
+                            if (match.isPrivate) ...[
+                              const SizedBox(height: 4),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 2,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.purple.withValues(alpha: 0.1),
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: const Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(
+                                      Icons.lock_outline,
+                                      size: 10,
+                                      color: Colors.purple,
+                                    ),
+                                    SizedBox(width: 4),
+                                    Text(
+                                      'Private',
+                                      style: TextStyle(
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.w600,
+                                        color: Colors.purple,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ],
                         ),
-                        const SizedBox(width: 6),
-                        Text(
-                          match.host!.displayName ?? 'Unknown',
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: AppTheme.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(width: 12),
+                      _StatusBadge(status: match.status),
+                    ],
+                  ),
 
-                  // Pending requests indicator for hosted matches
-                  if (isHosted && match.pendingPlayers.isNotEmpty)
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 4,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Colors.orange.withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(
-                            Icons.pending_actions,
-                            size: 14,
-                            color: Colors.orange,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            '${match.pendingPlayers.length} pending',
-                            style: const TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w500,
-                              color: Colors.orange,
-                            ),
-                          ),
-                        ],
-                      ),
+                  const SizedBox(height: 12),
+
+                  // Court info
+                  if (match.court != null) ...[
+                    _InfoRow(
+                      icon: Icons.location_on_outlined,
+                      text: match.court!.name,
+                      secondaryText: match.court!.addressDistrict,
                     ),
+                    const SizedBox(height: 8),
+                  ],
+
+                  // Date and time
+                  _InfoRow(
+                    icon: Icons.calendar_today_outlined,
+                    text: _formatDate(match.date),
+                    secondaryText: '${match.startTime} - ${match.endTime}',
+                  ),
+
+                  const SizedBox(height: 12),
+
+                  // Tags row: Skill level, format, slots
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _Tag(
+                        icon: Icons.bar_chart,
+                        label: match.skillLevel.displayName,
+                        color: AppTheme.primaryColor,
+                      ),
+                      _Tag(
+                        icon: Icons.people_outline,
+                        label: match.playerFormat.displayName,
+                        color: Colors.blue,
+                      ),
+                      _Tag(
+                        icon: Icons.person_add_outlined,
+                        label:
+                            '${match.totalPlayersCount}/${match.slotsNeeded}',
+                        color: match.isFull ? Colors.orange : Colors.green,
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 12),
+
+                  // Bottom row: Price + Host info
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      // Price
+                      Text(
+                        _formatPrice(match.price),
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: AppTheme.primaryColor,
+                        ),
+                      ),
+
+                      // Host info
+                      if (match.host != null && !isHosted)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            CircleAvatar(
+                              radius: 12,
+                              backgroundColor: AppTheme.primaryColor.withValues(
+                                alpha: 0.1,
+                              ),
+                              backgroundImage: match.host!.avatarUrl != null
+                                  ? NetworkImage(
+                                      ImageUrlHelper.transformImageUrl(
+                                        match.host!.avatarUrl!,
+                                      ),
+                                      headers: ImageUrlHelper.imageHeaders,
+                                    )
+                                  : null,
+                              child: match.host!.avatarUrl == null
+                                  ? Text(
+                                      match.host!.displayName?.isNotEmpty ==
+                                              true
+                                          ? match.host!.displayName![0]
+                                                .toUpperCase()
+                                          : 'U',
+                                      style: const TextStyle(
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                        color: AppTheme.primaryColor,
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              match.host!.displayName ?? 'Unknown',
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: AppTheme.textSecondary,
+                              ),
+                            ),
+                          ],
+                        ),
+
+                      // Pending requests indicator for hosted matches
+                      if (isHosted && match.pendingPlayers.isNotEmpty)
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.orange.withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.pending_actions,
+                                size: 14,
+                                color: Colors.orange,
+                              ),
+                              const SizedBox(width: 4),
+                              Text(
+                                '${match.pendingPlayers.length} pending',
+                                style: const TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                  color: Colors.orange,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
                 ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
-        ],
       ),
+    );
+  }
+
+  Widget _buildMediaArea() {
+    final imageUrl = match.images.isNotEmpty
+        ? ImageUrlHelper.transformImageUrl(match.images[0])
+        : null;
+
+    return ClipRRect(
+      key: const Key('match_card_media_area'),
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      child: imageUrl != null
+          ? CachedNetworkImage(
+              key: const Key('match_card_image'),
+              imageUrl: imageUrl,
+              httpHeaders: ImageUrlHelper.imageHeaders,
+              height: 180,
+              width: double.infinity,
+              fit: BoxFit.cover,
+              placeholder: (context, url) => Container(
+                height: 180,
+                color: Colors.grey.shade200,
+                child: const Center(child: CircularProgressIndicator()),
+              ),
+              errorWidget: (context, url, error) => _buildImagePlaceholder(),
+            )
+          : _buildImagePlaceholder(),
+    );
+  }
+
+  Widget _buildImagePlaceholder() {
+    return Container(
+      key: const Key('match_card_image_placeholder'),
+      height: 180,
+      width: double.infinity,
+      color: AppTheme.primaryColor.withValues(alpha: 0.08),
+      child: Icon(
+        Icons.sports_tennis,
+        size: 48,
+        color: AppTheme.primaryColor.withValues(alpha: 0.45),
       ),
     );
   }
@@ -378,21 +396,13 @@ class _InfoRow extends StatelessWidget {
   final String text;
   final String? secondaryText;
 
-  const _InfoRow({
-    required this.icon,
-    required this.text,
-    this.secondaryText,
-  });
+  const _InfoRow({required this.icon, required this.text, this.secondaryText});
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Icon(
-          icon,
-          size: 16,
-          color: AppTheme.textSecondary,
-        ),
+        Icon(icon, size: 16, color: AppTheme.textSecondary),
         const SizedBox(width: 8),
         Expanded(
           child: Row(
@@ -410,10 +420,7 @@ class _InfoRow extends StatelessWidget {
               if (secondaryText != null) ...[
                 const Text(
                   ' • ',
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: AppTheme.textHint,
-                  ),
+                  style: TextStyle(fontSize: 14, color: AppTheme.textHint),
                 ),
                 Flexible(
                   child: Text(
@@ -440,11 +447,7 @@ class _Tag extends StatelessWidget {
   final String label;
   final Color color;
 
-  const _Tag({
-    required this.icon,
-    required this.label,
-    required this.color,
-  });
+  const _Tag({required this.icon, required this.label, required this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -457,11 +460,7 @@ class _Tag extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            icon,
-            size: 12,
-            color: color,
-          ),
+          Icon(icon, size: 12, color: color),
           const SizedBox(width: 4),
           Text(
             label,

--- a/test/services/court_service_test.dart
+++ b/test/services/court_service_test.dart
@@ -187,9 +187,9 @@ void main() {
         verify(mockApiService.get(
           '/api/courts/nearby',
           queryParams: {
-            'latitude': '21.0285',
-            'longitude': '105.8542',
-            'radius': '5.0',
+            'lat': '21.0285',
+            'lng': '105.8542',
+            'radius': '5000', // meters
           },
         )).called(1);
       });

--- a/test/services/court_service_test.dart
+++ b/test/services/court_service_test.dart
@@ -209,9 +209,9 @@ void main() {
         verify(mockApiService.get(
           '/api/courts/nearby',
           queryParams: {
-            'latitude': '21.0285',
-            'longitude': '105.8542',
-            'radius': '10.0',
+            'lat': '21.0285',
+            'lng': '105.8542',
+            'radius': '10000',
           },
         )).called(1);
       });
@@ -547,4 +547,3 @@ void main() {
     });
   });
 }
-

--- a/test/services/image_url_helper_test.dart
+++ b/test/services/image_url_helper_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smatch_badminton/core/config/env.dart';
+import 'package:smatch_badminton/core/utils/image_url_helper.dart';
+
+void main() {
+  group('ImageUrlHelper', () {
+    test(
+      'transforms supported LocalStack S3 hostnames through backend proxy',
+      () {
+        final urls = [
+          'http://localhost:4566/smatch-photos/matches/1.jpg',
+          'http://127.0.0.1:4566/smatch-photos/matches/1.jpg',
+          'http://localstack:4566/smatch-photos/matches/1.jpg',
+          'http://s3.localhost.localstack.cloud:4566/smatch-photos/matches/1.jpg',
+        ];
+
+        for (final url in urls) {
+          expect(
+            ImageUrlHelper.transformImageUrl(url),
+            '${Env.apiBaseUrl}/api/s3-proxy/smatch-photos/matches/1.jpg',
+          );
+        }
+      },
+    );
+
+    test('keeps external and already proxied URLs unchanged', () {
+      final urls = [
+        'https://cdn.example.com/smatch-photos/matches/1.jpg',
+        '${Env.apiBaseUrl}/api/s3-proxy/smatch-photos/matches/1.jpg',
+      ];
+
+      for (final url in urls) {
+        expect(ImageUrlHelper.transformImageUrl(url), url);
+      }
+    });
+
+    test('transforms each URL in a list', () {
+      expect(
+        ImageUrlHelper.transformImageUrls([
+          'http://localhost:4566/smatch-photos/matches/1.jpg',
+          'https://cdn.example.com/smatch-photos/matches/2.jpg',
+        ]),
+        [
+          '${Env.apiBaseUrl}/api/s3-proxy/smatch-photos/matches/1.jpg',
+          'https://cdn.example.com/smatch-photos/matches/2.jpg',
+        ],
+      );
+    });
+  });
+}

--- a/test/widgets/match_card_test.dart
+++ b/test/widgets/match_card_test.dart
@@ -1,0 +1,72 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smatch_badminton/core/utils/image_url_helper.dart';
+import 'package:smatch_badminton/models/match.dart';
+import 'package:smatch_badminton/views/matches/widgets/match_card.dart';
+
+void main() {
+  group('MatchCard', () {
+    Widget createWidget(MatchWithDetails match) {
+      return MaterialApp(
+        home: Scaffold(body: MatchCard(match: match)),
+      );
+    }
+
+    testWidgets('renders a media placeholder when images are empty', (
+      tester,
+    ) async {
+      await tester.pumpWidget(createWidget(_matchWithImages()));
+
+      expect(find.byKey(const Key('match_card_media_area')), findsOneWidget);
+      expect(
+        find.byKey(const Key('match_card_image_placeholder')),
+        findsOneWidget,
+      );
+      expect(find.byType(CachedNetworkImage), findsNothing);
+    });
+
+    testWidgets('uses transformed image URL when an image is available', (
+      tester,
+    ) async {
+      const rawUrl = 'http://127.0.0.1:4566/smatch-photos/matches/1.jpg';
+
+      await tester.pumpWidget(createWidget(_matchWithImages(images: [rawUrl])));
+
+      final image = tester.widget<CachedNetworkImage>(
+        find.byKey(const Key('match_card_image')),
+      );
+
+      expect(image.imageUrl, ImageUrlHelper.transformImageUrl(rawUrl));
+      expect(find.byKey(const Key('match_card_media_area')), findsOneWidget);
+    });
+  });
+}
+
+MatchWithDetails _matchWithImages({List<String> images = const []}) {
+  return MatchWithDetails(
+    id: 'match-1',
+    courtId: 'court-1',
+    hostUserId: 'user-1',
+    title: 'Evening doubles',
+    images: images,
+    skillLevel: SkillLevel.tb,
+    shuttleType: ShuttleType.other,
+    playerFormat: PlayerFormat.doubleMale,
+    date: '2026-05-20',
+    startTime: '18:00',
+    endTime: '20:00',
+    isPrivate: false,
+    price: 50000,
+    slotsNeeded: 4,
+    status: MatchStatus.open,
+    createdAt: DateTime(2026, 5, 20),
+    updatedAt: DateTime(2026, 5, 20),
+    court: const MatchCourt(
+      id: 'court-1',
+      name: 'Smatch Court',
+      addressDistrict: 'Cau Giay',
+    ),
+    host: const MatchHost(id: 'user-1', displayName: 'Minh'),
+  );
+}


### PR DESCRIPTION
This pull request updates the query parameter names and values used in the test for the nearby courts API to match the expected backend contract.

API parameter updates:

* Changed the parameter names in the `get` request from `'latitude'` and `'longitude'` to `'lat'` and `'lng'`, and updated the `'radius'` value from `'5.0'` (kilometers) to `'5000'` (meters) in `court_service_test.dart` to align with the backend API specification.